### PR TITLE
Adding default_factory to avoid ValueError in @dataclass

### DIFF
--- a/docuverse/engines/search_engine_config_params.py
+++ b/docuverse/engines/search_engine_config_params.py
@@ -375,8 +375,8 @@ class RetrievalArguments(GenericArguments):
         }
     )
 
-    query_template: DataTemplate = default_query_template
-    data_template: DataTemplate = default_data_template
+    query_template: DataTemplate = field(default_factory=lambda: default_query_template)
+    data_template: DataTemplate = field(default_factory=lambda: default_data_template)
 
     def __post_init__(self):
         # parse the query_header_template


### PR DESCRIPTION
Python 3.11 has issues with the definition of data classes containing non hashable fields. It interprets these fields as mutable, and requires the use of default_factory to instantiate them. For more info see [here](https://docs.python.org/3/library/dataclasses.html#mutable-default-values).

Full stack trace:

```python

Traceback (most recent call last):
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/tests/chunker_cmp.py", line 9, in <module>
    from rageval.components.chunking.fixed_size_token_chunker_docuverse import FixedSizeTokenChunkerDocUVerse
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/rageval/components/chunking/fixed_size_token_chunker_docuverse.py", line 12, in <module>
    from docuverse.utils.text_tiler import TextTiler
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/venv/lib/python3.11/site-packages/docuverse/__init__.py", line 1, in <module>
    from .engines import SearchCorpus, SearchQueries, SearchResult, SearchEngine
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/venv/lib/python3.11/site-packages/docuverse/engines/__init__.py", line 5, in <module>
    from docuverse.engines.retrieval.retrieval_engine import RetrievalEngine
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/venv/lib/python3.11/site-packages/docuverse/engines/retrieval/__init__.py", line 1, in <module>
    from .retrieval_engine import RetrievalEngine
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/venv/lib/python3.11/site-packages/docuverse/engines/retrieval/retrieval_engine.py", line 6, in <module>
    from docuverse.engines.search_engine_config_params import SearchEngineConfig, RetrievalArguments
  File "/Users/assaft/workspace/rag-app/rag_eval/RAGEval/venv/lib/python3.11/site-packages/docuverse/engines/search_engine_config_params.py", line 26, in <module>
    @dataclass
     ^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'docuverse.engines.data_template.DataTemplate'> for field query_template is not allowed: use default_factory
```

Note that the current fix assigns the same instance of `default_query_template` and `default_data_template` to all instances of `RetrievalArguments` - so data is shared. Not sure this was the intention . It's easy to change and create separate instances.