### PR TITLE
Unused, and no available version for Python 3.11.6 on MacOS

### DIFF
--- a/docuverse/engines/search_engine.py
+++ b/docuverse/engines/search_engine.py
@@ -9,7 +9,6 @@ from pydantic_core.core_schema import LiteralSchema
 from tqdm import tqdm
 from copy import deepcopy
 
-from triton.language.extra.cuda import num_threads
 
 from docuverse.utils import (
     open_stream,


### PR DESCRIPTION
the title says it all.